### PR TITLE
Fix QQ NT close button issue

### DIFF
--- a/SmartSystemMenu/SmartSystemMenu.xml
+++ b/SmartSystemMenu/SmartSystemMenu.xml
@@ -11,6 +11,8 @@
     <processName>chrome.exe</processName>
     <processName>msedge.exe</processName>
     <processName>firefox.exe</processName>
+    <processName>QQ.exe</processName>
+    <processName>QQNT.exe</processName>
     <processName>WindowsTerminal.exe</processName>
     <processName>code.exe</processName>
   </createMenuOnInitEvent>


### PR DESCRIPTION
Fix QQ NT close button issue

- Added QQ.exe and QQNT.exe to the process exclusion list to fix the issue, where close buttons in QQ NT (Electron app) were not functioning properly