### PR TITLE
Update SmartSystemMenu.xml alignment hotkeys

### DIFF
--- a/SmartSystemMenu/SmartSystemMenu.xml
+++ b/SmartSystemMenu/SmartSystemMenu.xml
@@ -51,15 +51,15 @@
       <item type="group" name="move_to" />
       <item type="group" name="alignment">
         <items>
-          <item type="item" name="align_top_left" key1="18" key2="" key3="103" />
-          <item type="item" name="align_top_center" key1="18" key2="" key3="104" />
-          <item type="item" name="align_top_right" key1="18" key2="" key3="105" />
-          <item type="item" name="align_middle_left" key1="18" key2="" key3="100" />
-          <item type="item" name="align_middle_center" key1="18" key2="" key3="101" />
-          <item type="item" name="align_middle_right" key1="18" key2="" key3="102" />
-          <item type="item" name="align_bottom_left" key1="18" key2="" key3="97" />
-          <item type="item" name="align_bottom_center" key1="18" key2="" key3="98" />
-          <item type="item" name="align_bottom_right" key1="18" key2="" key3="99" />
+          <item type="item" name="align_top_left" key1="91" key2="18" key3="103" />
+          <item type="item" name="align_top_center" key1="91" key2="18" key3="104" />
+          <item type="item" name="align_top_right" key1="91" key2="18" key3="105" />
+          <item type="item" name="align_middle_left" key1="91" key2="18" key3="100" />
+          <item type="item" name="align_middle_center" key1="91" key2="18" key3="101" />
+          <item type="item" name="align_middle_right" key1="91" key2="18" key3="102" />
+          <item type="item" name="align_bottom_left" key1="91" key2="18" key3="97" />
+          <item type="item" name="align_bottom_center" key1="91" key2="18" key3="98" />
+          <item type="item" name="align_bottom_right" key1="91" key2="18" key3="99" />
           <item type="separator" />
           <item type="item" name="align_center_horizontally" key1="" key2="" key3="" />
           <item type="item" name="align_center_vertically" key1="" key2="" key3="" />


### PR DESCRIPTION
The current hotkey defaults for window alignment prevent alt code typing from working (e.g. using `Alt`+`0233` to type the character `é`). This PR updates the window alignment hotkeys to use `Win`+`Alt` rather than just `Alt` to eliminate the conflict. Since the action is for window alignment, I think the Windows key is an intuitive choice.